### PR TITLE
Fixed null iterator error

### DIFF
--- a/src/helper.cpp
+++ b/src/helper.cpp
@@ -27,14 +27,14 @@ extern void insert_element(multiset<double>& m, multiset<double, std::greater<do
 	if(m.size() > M.size() + 1){
 		multiset<double>::iterator i;
 		i = m.begin();
-		m.erase(m.begin());
 		M.insert(*i);
+		m.erase(m.begin());
 	}
 	else if(M.size() > m.size() + 1){
 		multiset<double, std::greater<double> >::iterator i;
 		i = M.begin();
-		M.erase(M.begin());
 		m.insert(*i);
+		M.erase(M.begin());
 	}
 }
 
@@ -65,13 +65,13 @@ extern void remove_element(multiset<double>& m, multiset<double, std::greater<do
 	if(m.size() > M.size() + 1){
 		multiset<double>::iterator i;
 		i = m.begin();
-		m.erase(m.begin());
 		M.insert(*i);
+		m.erase(m.begin());
 	}
 	else if(M.size() > m.size() + 1){
 		multiset<double, std::greater<double> >::iterator i;
 		i = M.begin();
-		M.erase(M.begin());
 		m.insert(*i);
+		M.erase(M.begin());
 	}
 }


### PR DESCRIPTION
When calling erase on a set it invalidates all of the iterators pointing to the removed element. For compilers that strictly adhere to the c++ standard this will insert a random double into the set. 

This issue has been fixed by inserting elements before calling the erase function.
